### PR TITLE
Updated the broken 96boards link in the optee content (docs/hikey.md)

### DIFF
--- a/docs/hikey.md
+++ b/docs/hikey.md
@@ -146,7 +146,7 @@ $ make recovery
 ```
 
 [AOSP HiKey branch]: https://source.android.com/source/devices.html
-[official HiKey documentation]: https://www.96boards.org/documentation/ConsumerEdition/HiKey/
+[official HiKey documentation]: https://www.96boards.org/documentation/consumer/hikey/
 [OP-TEE Android Manifest]: https://github.com/linaro-swg/optee_android_manifest
 [README.md]: ../../build/
 [hikey.mk]: https://github.com/OP-TEE/build/blob/master/hikey.mk


### PR DESCRIPTION
Broken link fixed which is stopping the bamboo build from passing.
@shovanuk @pcolmer 

