### PR TITLE
projects: Fix inconsistent link

### DIFF
--- a/projects/projects.html
+++ b/projects/projects.html
@@ -31,7 +31,7 @@ layout: container-breadcrumb
     </div>
 
     <div class="col-md-4">
-        <a href="https://github.com/OP-TEE/optee_client">
+        <a href="https://github.com/OP-TEE/optee_test">
             <i class="fa fa-github project-icon fa-5x text-center center-block" class="project"  aria-hidden="true"></i>
             <h4 class="project-title text-center">optee_test</h4>
         </a>


### PR DESCRIPTION
The optee_test heading was linking to the optee_client GitHub repo,
while the More Info link was pointing to optee_test. Fix this.