### PR TITLE
Fix for vulnerable gem issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
 source "https://rubygems.org"
 
-gem "jumbo-jekyll-theme", "2.1.0"
+gem "jumbo-jekyll-theme", "2.2.0"
 
 group :jekyll_plugins do
   gem "jekyll-data"
   gem "mini_magick"
-  gem "ffi", "1.9.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     extras (0.3.0)
       forwardable-extended (~> 2.5)
     fastimage (2.1.4)
-    ffi (1.9.0)
+    ffi (1.9.25)
     forwardable-extended (2.6.0)
     hash-joiner (0.0.7)
       safe_yaml
@@ -28,7 +28,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.3)
+    jekyll (3.7.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -53,6 +53,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-feed (0.11.0)
       jekyll (~> 3.3)
+    jekyll-include-cache (0.1.0)
+      jekyll (~> 3.3)
     jekyll-paginate-v2 (2.0.0)
       jekyll (~> 3.0)
     jekyll-readme-index (0.2.0)
@@ -72,17 +74,19 @@ GEM
       htmlbeautifier
       htmlcompressor
       jekyll
-    jekyll-watch (2.0.0)
+    jekyll-watch (2.1.0)
       listen (~> 3.0)
     json (2.1.0)
-    jumbo-jekyll-theme (2.1.0)
+    jumbo-jekyll-theme (2.2.0)
       autoprefixer-rails (~> 5.0, >= 5.0.0.1)
       bootstrap-sass (~> 3.3)
+      ffi (~> 1.9.24)
       hash-joiner (~> 0)
-      jekyll (= 3.7.3)
+      jekyll (~> 3.7.4)
       jekyll-assets (= 2.4.0)
       jekyll-data (> 0)
       jekyll-feed (> 0)
+      jekyll-include-cache
       jekyll-paginate-v2 (> 0)
       jekyll-readme-index (= 0.2)
       jekyll-redirect-from (~> 0.12)
@@ -93,7 +97,7 @@ GEM
       sprockets (~> 3.7.2)
       uglifier (> 0)
     kramdown (1.17.0)
-    liquid (4.0.0)
+    liquid (4.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -107,7 +111,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rouge (3.2.1)
+    rouge (3.3.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sass (3.6.0)
@@ -125,10 +129,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ffi (= 1.9.0)
   jekyll-data
-  jumbo-jekyll-theme (= 2.1.0)
+  jumbo-jekyll-theme (= 2.2.0)
   mini_magick
 
 BUNDLED WITH
-   1.16.5
+   1.16.2


### PR DESCRIPTION
I've updated the jumbo-jekyll-theme to use the latest versions of jekyll and ffi.
- ffi (1.9.25)
- jekyll (3.7.4)