### PR TITLE
Replaced Cognito forms with a static contact button

### DIFF
--- a/assets/css/app/custom.scss
+++ b/assets/css/app/custom.scss
@@ -61,3 +61,22 @@ div#contact-thanks {
 #content-container #homepage-text p {
     font-size: 18px;
 }
+// CSS for the email button.
+#wrapper .email {
+    height: 50px;
+    background-color: $brand-primary;
+    width: 200px;
+    line-height: 30px;
+    text-align: center;
+    color: white;
+    font-weight: bold;
+    border: 1px solid #9e9e9e;
+    margin-left: auto;
+    margin-right: auto;
+    transition: all 200ms ease;
+}
+#wrapper .email:hover {
+    background-color: #3a3a3a;
+    border: 1px solid #000000;
+    color:white;
+}

--- a/contact/contact.html
+++ b/contact/contact.html
@@ -8,11 +8,8 @@ layout: full-width-breadcrumb
         <h3 class="text-center animated fadeIn">Get in Contact. Get Involved. Get the Code. </h3>
     </div>
 </div>
-    
-
 <div class="container-fluid">
     <div class="container">
-        <!-- Tab panes -->
       <div class="row">
       <div class="col-md-4">
           <h1>Contact Info</h1>
@@ -25,15 +22,15 @@ layout: full-width-breadcrumb
               CB22 7GG<br>
           </address>
       </div>
-      <div class="col-md-8">        
-        <div class="cognito">
-            <script src="https://services.cognitoforms.com/s/KvRQmIn2dku6k6gGP711jw"></script>
-            <script>
-            Cognito.load("forms", { id: "2", entry: {
-                "PageUrl": "{{site.url}}{{page.url}}" ,
-                "RedirectUrl" : "{{site.url}}/thank-you/?ref={{page.url}}"
-            }});
-            </script>
+      <div class="col-md-8">
+        <p>
+            For public queries, questions etc, please submit an issue at <a href="https://github.com/OP-TEE/optee_os/issues" target="_blank">GitHub/OP-TEE/optee_os/issues</a>.
+            For private issues send get in touch using the contact button below:
+        </p>
+        <div class="text-center">
+            <a class="btn email" href="mailto:contact@linaro.org?subject=OP-TEE.org - Contact Us">
+                Contact Us
+            </a>
         </div>
       </div>
       </div>

--- a/contact/contact.html
+++ b/contact/contact.html
@@ -27,6 +27,7 @@ layout: full-width-breadcrumb
             For public queries, questions etc, please submit an issue at <a href="https://github.com/OP-TEE/optee_os/issues" target="_blank">GitHub/OP-TEE/optee_os/issues</a>.
             For private issues send get in touch using the contact button below:
         </p>
+        <br>
         <div class="text-center">
             <a class="btn email" href="mailto:contact@linaro.org?subject=OP-TEE.org - Contact Us">
                 Contact Us


### PR DESCRIPTION
We are replacing the Cognito forms on our static websites with a simple contact button using a mailto: link and a prefilled subject line to automatically assign tickets which come in. This will allow us to track who is working on which ticket in the Service Desk portal.