### PR TITLE
Added temporary footer override to fix cached page url bug in mailto link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,68 @@
+<footer>
+    <div class="row footer footer-main p-t-40">
+        <div class="container">
+            {% if site.data.footer.display-contact-details %}
+            <div class="col-xs-12 col-sm-3 contact-details">
+                <address>
+                    <a class="email" href="mailto:{{site.email}}?subject=OP-TEE">{{site.email}}</a> <br>
+                    {% for address-line in site.address %}
+                        {{address-line}}<br>
+                    {% endfor %}
+                </address>
+            </div>
+            {% endif %}
+            {% if site.data.footer.second-column %}
+            <div class="col-xs-12 col-sm-3 footer-column">
+                <h3>{{site.data.footer.second-column.title}}</h3>
+                <ul class="list-group">
+                    {% if site.data.footer.second-column.latest-posts %}
+                        {% include_cached latest-posts.html %}
+                    {% else %}
+                        {% for item in site.data.footer.second-column.items %}
+                        <li class="list-group-item">
+                            <a href="{{item.url}}">{{item.name}}</a>
+                        </li>
+                        {% endfor %}
+                    {% endif %}
+                </ul>
+            </div>
+            {% endif %}
+            {% if site.data.footer.third-column %}
+            <div class="col-xs-12 col-sm-3 footer-column">
+                <h3>{{site.data.footer.third-column.title}}</h3>
+                <ul class="list-group">
+                    {% for item in site.data.footer.third-column.items %}
+                        <li class="list-group-item">
+                            <a href="{{item.url}}">{{item.name}}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+            {% if site.data.footer.social-media-icons %}
+            <div class="col-xs-12 col-sm-3 footer-column footer-follow-section">
+                <h3>Follow us</h3>
+                {% include_cached social-media-icons.html %}
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    <div class="row footer-bottom p-t-20 p-b-20">
+        <div class="container">
+            <div class="col-xs-12 text-white text-center">
+                Copyright &copy; {{ 'now' | date: "%Y" }} {{site.data.footer.copyright-text}}
+                {% for link in site.data.footer.company-links %}
+                    <span class="coloured-bp">&bull;</span>
+                    <a href="{{link.url}}">{{link.name}}</a> 
+                {% endfor %}
+            </div>
+            <div class="col-xs-12 text-white text-center m-t-10">
+                {% if site.data.footer.linaro-branding %}
+                    <a href="https://www.linaro.org">
+                        <img src="/assets/images/Linaro-logo-white.png" class="footer-logo" alt="Linaro Logo White Footer Icon" />
+                    </a>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</footer>


### PR DESCRIPTION
This PR will fix an issue I noticed with the mailto: url being cached agressively and including /404.html for the page url in the subject parameter.