### PR TITLE
main page: fix spelling error

### DIFF
--- a/_pages/homepage.md
+++ b/_pages/homepage.md
@@ -27,7 +27,7 @@ flow:
       - format: text
         text_content:
           text: >
-            OP-TEE is an open source Trusted Execution Enviroment (TEE) implementing the
+            OP-TEE is an open source Trusted Execution Environment (TEE) implementing the
             [Arm TrustZone technology](https://developer.arm.com/ip-products/security-ip/trustzone).
             OP-TEE has been ported to many Arm [devices and
             platforms](https://optee.readthedocs.io/en/latest/general/platforms.html).


### PR DESCRIPTION
On the main page it said Enviroment in one place, which should be Environment instead.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Reported-by: Jun Li <junli_1632021@163.com>